### PR TITLE
fix(ignition): add missing contract wiring to DeploySystem module

### DIFF
--- a/packages/contracts/ignition/modules/DeploySystem.ts
+++ b/packages/contracts/ignition/modules/DeploySystem.ts
@@ -10,10 +10,19 @@ const DeploySystemModule = buildModule("DeploySystem", (m) => {
   const { dataRegistry } = m.useModule(DataRegistryModule);
   const { escrowManager } = m.useModule(EscrowManagerModule);
 
+  // Wire up FunctionsConsumer
   m.call(functionsConsumer, "updateDataRegistry", [dataRegistry]);
 
+  // Wire up EscrowManager (bidirectional references)
   m.call(escrowManager, "setBountyRegistry", [bountyRegistry]);
   m.call(escrowManager, "setDataRegistry", [dataRegistry]);
+
+  // Wire up BountyRegistry
+  m.call(bountyRegistry, "setEscrowManager", [escrowManager]);
+  m.call(bountyRegistry, "setDataRegistry", [dataRegistry]);
+
+  // Wire up DataRegistry
+  m.call(dataRegistry, "setEscrowManager", [escrowManager]);
 
   return {
     bountyRegistry,


### PR DESCRIPTION
## Summary
Add missing setter calls required for contracts to function properly after deployment.

## Problem
The `DeploySystem.ts` Ignition module was missing critical wiring calls, which would cause deployed contracts to fail:

| Missing Call | Error |
|--------------|-------|
| `bountyRegistry.setEscrowManager(escrowManager)` | `createBounty()` reverts with `EscrowManagerNotSet` |
| `bountyRegistry.setDataRegistry(dataRegistry)` | `completeBounty()` and `incrementSubmissions()` revert with `DataRegistryNotSet` |
| `dataRegistry.setEscrowManager(escrowManager)` | Payment release fails |

## Solution
Added the missing calls to properly wire all contracts:

```typescript
// Wire up BountyRegistry
m.call(bountyRegistry, "setEscrowManager", [escrowManager]);
m.call(bountyRegistry, "setDataRegistry", [dataRegistry]);

// Wire up DataRegistry
m.call(dataRegistry, "setEscrowManager", [escrowManager]);
```

## Test plan
- [x] Contracts compile successfully
- [x] `npx hardhat ignition deploy ignition/modules/DeploySystem.ts --network localhost` deploys and wires all contracts
- [x] All 93 tests passing

## Summary by Sourcery

Wire the deployed contracts together in the DeploySystem Ignition module so they reference each other correctly after deployment.

Bug Fixes:
- Configure BountyRegistry to use EscrowManager and DataRegistry so bounty creation and completion no longer revert due to missing dependencies.
- Configure DataRegistry to use EscrowManager so payment release works after deployment.

Enhancements:
- Document the contract wiring steps within the DeploySystem Ignition module for clearer deployment configuration.