### PR TITLE
feat(sdk): add browser and node usage examples

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -204,30 +204,76 @@ Example of submitting data for a bounty:
 import { StorachaBountyClient } from "@storacha-chainlink/sdk";
 import { ethers } from "ethers";
 
-// Initialize Storacha client
 const storacha = await StorachaBountyClient.create();
 await storacha.authorize("contributor@example.com");
 await storacha.createSpace({ name: "my-submissions" });
 
-// Prepare and upload bounty data
 const bountyData = {
   bountyId: 1,
   timestamp: Date.now(),
-  data: {
-    // Your submission data here
-  },
+  data: {},
 };
 
 const upload = await storacha.uploadJSON(bountyData);
-console.log("Data CID:", upload.cidString);
 
-// Submit to smart contract
 const dataRegistry = new ethers.Contract(DATA_REGISTRY_ADDRESS, ABI, signer);
 await dataRegistry.submitData(
-  1, // bountyId
-  upload.cidString, // CID
-  JSON.stringify({ name: "My Submission" }), // metadata
+  1,
+  upload.cidString,
+  JSON.stringify({ name: "My Submission" }),
 );
+```
+
+## Examples
+
+### Node script example
+
+An end-to-end Node script that uploads JSON and submits the resulting CID to `DataRegistry` is available at:
+
+- `packages/sdk/examples/node/submit-bounty.mjs`
+
+Prerequisites:
+
+- Build the SDK:
+
+```bash
+pnpm build --filter @storacha-chainlink/sdk
+```
+
+- Set environment variables:
+
+```bash
+export RPC_URL="https://sepolia.example"
+export PRIVATE_KEY="0x..."
+export DATA_REGISTRY_ADDRESS="0x..."
+export STORACHA_EMAIL="contributor@example.com"
+export BOUNTY_ID="1"
+```
+
+Run the script:
+
+```bash
+node packages/sdk/examples/node/submit-bounty.mjs
+```
+
+### Browser example
+
+A minimal browser example that authorizes with email, creates a space, and uploads JSON is available at:
+
+- `packages/sdk/examples/browser/index.html`
+
+Prerequisites:
+
+- Build the SDK:
+
+```bash
+pnpm build --filter @storacha-chainlink/sdk
+```
+
+- Serve the examples directory with any static file server, then open the HTML file in a browser:
+
+```bash
+npx serve packages/sdk/examples/browser
 ```
 
 ## Security Considerations

--- a/packages/sdk/examples/browser/browser-example.js
+++ b/packages/sdk/examples/browser/browser-example.js
@@ -1,0 +1,78 @@
+import { StorachaBountyClient } from "../../dist/index.js";
+
+const form = document.querySelector("form");
+const output = document.getElementById("output");
+
+async function handleSubmit(event) {
+  event.preventDefault();
+
+  if (!form || !output) {
+    return;
+  }
+
+  const emailInput = document.getElementById("email");
+  const bountyIdInput = document.getElementById("bountyId");
+
+  if (!(emailInput instanceof HTMLInputElement)) {
+    return;
+  }
+
+  const email = emailInput.value.trim();
+
+  if (!email) {
+    output.textContent = "Email is required";
+    return;
+  }
+
+  const bountyId =
+    bountyIdInput instanceof HTMLInputElement &&
+    Number.isFinite(Number(bountyIdInput.value))
+      ? Number(bountyIdInput.value)
+      : 1;
+
+  output.textContent = "Authorizing and uploading...";
+
+  try {
+    const client = await StorachaBountyClient.create();
+    await client.authorize(email);
+
+    await client.createSpace({ name: "browser-bounty-space" });
+
+    const bountyData = {
+      bountyId,
+      timestamp: Date.now(),
+      data: {
+        value: Math.random(),
+      },
+    };
+
+    const result = await client.uploadJSON(bountyData);
+
+    const metadata = JSON.stringify({
+      name: "Browser example submission",
+    });
+
+    const submitArgs = {
+      bountyId,
+      cid: result.cidString,
+      metadata,
+    };
+
+    output.textContent = [
+      `Uploaded CID: ${result.cidString}`,
+      "",
+      "Example submitData arguments:",
+      `bountyId: ${submitArgs.bountyId}`,
+      `cid: ${submitArgs.cid}`,
+      `metadata: ${submitArgs.metadata}`,
+    ].join("\n");
+  } catch (error) {
+    output.textContent = String(error);
+  }
+}
+
+if (form) {
+  form.addEventListener("submit", (event) => {
+    handleSubmit(event);
+  });
+}

--- a/packages/sdk/examples/browser/index.html
+++ b/packages/sdk/examples/browser/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Storacha SDK Browser Example</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <main>
+      <h1>Storacha SDK Browser Example</h1>
+      <form>
+        <label>
+          Email
+          <input id="email" type="email" required />
+        </label>
+        <label>
+          Bounty ID
+          <input id="bountyId" type="number" min="1" />
+        </label>
+        <button type="submit">Authorize and upload JSON</button>
+      </form>
+      <pre id="output"></pre>
+    </main>
+    <script type="module" src="./browser-example.js"></script>
+  </body>
+</html>
+

--- a/packages/sdk/examples/node/submit-bounty.mjs
+++ b/packages/sdk/examples/node/submit-bounty.mjs
@@ -1,0 +1,71 @@
+import { StorachaBountyClient } from "@storacha-chainlink/sdk";
+import { ethers } from "ethers";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const rpcUrl = process.env.RPC_URL;
+const privateKey = process.env.PRIVATE_KEY;
+const dataRegistryAddress = process.env.DATA_REGISTRY_ADDRESS;
+const bountyIdEnv = process.env.BOUNTY_ID;
+const storachaEmail = process.env.STORACHA_EMAIL;
+
+async function main() {
+  if (!rpcUrl || !privateKey || !dataRegistryAddress || !storachaEmail) {
+    throw new Error(
+      "RPC_URL, PRIVATE_KEY, DATA_REGISTRY_ADDRESS, STORACHA_EMAIL must be set",
+    );
+  }
+
+  const storacha = await StorachaBountyClient.create();
+  await storacha.authorize(storachaEmail);
+  await storacha.createSpace({ name: "bounty-submissions" });
+
+  const bountyId =
+    bountyIdEnv && Number.isFinite(Number(bountyIdEnv))
+      ? Number(bountyIdEnv)
+      : 1;
+
+  const bountyData = {
+    bountyId,
+    timestamp: Date.now(),
+    data: {
+      value: Math.random(),
+    },
+  };
+
+  const upload = await storacha.uploadJSON(bountyData);
+
+  console.log("Uploaded CID:", upload.cidString);
+
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(privateKey, provider);
+
+  const abi = [
+    "function submitData(uint256 bountyId, string cid, string metadata) external returns (uint256)",
+  ];
+
+  const dataRegistry = new ethers.Contract(
+    dataRegistryAddress,
+    abi,
+    wallet,
+  );
+
+  const metadata = JSON.stringify({
+    name: "SDK Node example submission",
+  });
+
+  const tx = await dataRegistry.submitData(
+    bountyId,
+    upload.cidString,
+    metadata,
+  );
+
+  console.log("Submitted transaction:", tx.hash);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -42,6 +42,8 @@
     "@storacha-chainlink/typescript-config": "workspace:*",
     "@types/node": "^22.15.3",
     "@vitest/coverage-v8": "^3.0.0",
+    "dotenv": "^16.0.3",
+    "ethers": "^6.14.0",
     "typescript": "^5.9.2",
     "vitest": "^3.0.0"
   },

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -57,7 +57,7 @@ export class StorachaBountyClient {
    * @returns A new StorachaBountyClient instance
    */
   static async create(
-    _config?: StorachaBountyClientConfig,
+    config?: StorachaBountyClientConfig,
   ): Promise<StorachaBountyClient> {
     const client = await Client.create();
     return new StorachaBountyClient(client);


### PR DESCRIPTION
This PR implements runnable browser and Node examples for `@storacha-chainlink/sdk` and documents how to use them. The goal is to make it easy for integrators to verify their environment and see how Storacha uploads connect to the bounty contracts.

**Changes**

* Added Node example: `packages/sdk/examples/node/submit-bounty.mjs`

  * Uses `StorachaBountyClient` for email auth, space creation, and JSON upload
  * Uses `ethers` to call `DataRegistry.submitData(bountyId, cid, metadata)` with the uploaded CID
  * Reads configuration from `RPC_URL`, `PRIVATE_KEY`, `DATA_REGISTRY_ADDRESS`, `STORACHA_EMAIL`, `BOUNTY_ID`

* Added browser example: `packages/sdk/examples/browser/index.html` and `browser-example.js`

  * Simple form to enter email and optional bounty ID
  * Performs email auth and creates a dedicated space
  * Uploads JSON and prints the CID
  * Shows example `submitData` arguments (`bountyId`, `cid`, `metadata`) in the UI for later use

* Updated `packages/sdk/README.md`

  * Added “Examples” section linking to both examples
  * Included build, environment, and run instructions for Node and browser flows

* Updated `packages/sdk/package.json` devDependencies to include `ethers` and `dotenv` for the Node script


**How to test**

* Build the SDK:

```bash
pnpm build --filter @storacha-chainlink/sdk
```

* **Node example**

  * Set env vars: `RPC_URL`, `PRIVATE_KEY`, `DATA_REGISTRY_ADDRESS`, `STORACHA_EMAIL`, `BOUNTY_ID`
  * Run:

```bash
node packages/sdk/examples/node/submit-bounty.mjs
```

* Verify it logs the uploaded CID and a `submitData` transaction hash

* **Browser example**

  * Serve the browser examples:

```bash
npx serve packages/sdk/examples/browser
```

* Open `index.html` in a browser, enter an email and optional bounty ID, and verify:

  * You receive the Storacha auth email
  * A CID is displayed
  * The example `submitData` arguments are shown (`bountyId`, `cid`, `metadata`)

* Closes #38

## Summary by Sourcery

Add runnable Node and browser examples for the Storacha SDK and document how to use them for uploading bounty data and preparing on-chain submissions.

New Features:
- Provide a Node script example that uploads JSON via Storacha and submits the resulting CID to the DataRegistry contract using environment-based configuration.
- Provide a browser example that performs email authorization, creates a space, uploads JSON, and displays the resulting CID and example submitData arguments.

Enhancements:
- Document SDK usage examples in the README, including build prerequisites and run instructions for Node and browser flows.
- Allow StorachaBountyClient.create to accept a configuration parameter for future customization.

Build:
- Add ethers and dotenv as devDependencies to support the Node example script.