### PR TITLE
chore(env): add .env.example files for root, contracts and frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# Root environment variables for Storacha × Chainlink monorepo
+# Copy this file to `.env` at the repo root and fill in real values.
+
+# -------------------------
+# Blockchain RPC Endpoints
+# -------------------------
+SEPOLIA_RPC_URL= # HTTPS RPC URL for Ethereum Sepolia
+ARBITRUM_SEPOLIA_RPC_URL= # HTTPS RPC URL for Arbitrum Sepolia
+
+# -------------------------
+# Deployment Credentials
+# -------------------------
+PRIVATE_KEY= # Deployer private key for testnets (never commit real keys)
+
+# -------------------------
+# Block Explorer API Keys
+# -------------------------
+ETHERSCAN_API_KEY= # Etherscan API key for Ethereum Sepolia
+ARBISCAN_API_KEY= # Arbiscan API key for Arbitrum Sepolia
+
+# -------------------------
+# Chainlink Functions
+# -------------------------
+CHAINLINK_ROUTER= # Chainlink Functions router address for target network
+SUBSCRIPTION_ID= # Chainlink Functions subscription ID for routing requests
+DON_ID= # Chainlink DON ID (e.g. fun-ethereum-sepolia-1)
+
+# -------------------------
+# Frontend Contract Config
+# -------------------------
+NEXT_PUBLIC_BOUNTY_REGISTRY_ADDRESS= # BountyRegistry contract address (0x...)
+NEXT_PUBLIC_DATA_REGISTRY_ADDRESS= # DataRegistry contract address (0x...)
+
+# -------------------------
+# Wallet / Web3 Integrations
+# -------------------------
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID= # WalletConnect Cloud project ID used by RainbowKit
+

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,14 @@
+# Environment variables for @storacha-chainlink/frontend
+# Copy to `.env.local` or `.env` in this directory and fill in real values.
+
+# -------------------------
+# Contract Addresses
+# -------------------------
+NEXT_PUBLIC_BOUNTY_REGISTRY_ADDRESS= # BountyRegistry contract address (0x...) used by the frontend
+NEXT_PUBLIC_DATA_REGISTRY_ADDRESS= # DataRegistry contract address (0x...) used by the frontend
+
+# -------------------------
+# Wallet / Web3 Integrations
+# -------------------------
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID= # WalletConnect Cloud project ID used by RainbowKit
+

--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # env files (can opt-in for commiting if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -1,5 +1,27 @@
-SEPOLIA_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
-ARBITRUM_SEPOLIA_RPC_URL=https://sepolia-rollup.arbitrum.io/rpc
-PRIVATE_KEY=
-ETHERSCAN_API_KEY=
-ARBISCAN_API_KEY=
+# Environment variables for @storacha-chainlink/contracts
+# Copy to `.env` at the repo root or adjust `hardhat.config.ts` to load this file directly.
+
+# -------------------------
+# Blockchain RPC Endpoints
+# -------------------------
+SEPOLIA_RPC_URL= # HTTPS RPC URL for Ethereum Sepolia (used for sepolia network)
+ARBITRUM_SEPOLIA_RPC_URL= # HTTPS RPC URL for Arbitrum Sepolia (used for arbitrumSepolia network)
+
+# -------------------------
+# Deployment Credentials
+# -------------------------
+PRIVATE_KEY= # Deployer private key for testnets (0x-prefixed, never commit real keys)
+
+# -------------------------
+# Block Explorer API Keys
+# -------------------------
+ETHERSCAN_API_KEY= # Etherscan API key for contract verification on Sepolia
+ARBISCAN_API_KEY= # Arbiscan API key for contract verification on Arbitrum Sepolia
+
+# -------------------------
+# Chainlink Functions Config
+# -------------------------
+CHAINLINK_ROUTER= # Chainlink Functions router address for chosen network
+SUBSCRIPTION_ID= # Chainlink Functions subscription ID funding requests
+DON_ID= # Chainlink DON ID string (e.g. fun-ethereum-sepolia-1)
+


### PR DESCRIPTION
This PR adds `.env.example` files across the monorepo so new contributors can quickly see which environment variables are required and how they’re used, without digging through code. It documents shared RPC settings, deployment keys, Chainlink config, frontend contract addresses, and WalletConnect integration.

## Changes

- Root
  - Add `.env.example` at the repo root documenting shared variables:
    - `SEPOLIA_RPC_URL`, `ARBITRUM_SEPOLIA_RPC_URL` for Sepolia/Arbitrum RPC endpoints.
    - `PRIVATE_KEY` for testnet deployments (with a clear warning not to commit real keys).
    - `ETHERSCAN_API_KEY`, `ARBISCAN_API_KEY` for contract verification.
    - `CHAINLINK_ROUTER`, `SUBSCRIPTION_ID`, `DON_ID` for Chainlink Functions.
    - `NEXT_PUBLIC_BOUNTY_REGISTRY_ADDRESS`, `NEXT_PUBLIC_DATA_REGISTRY_ADDRESS` for deployed contract addresses.
    - `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` for RainbowKit / WalletConnect.

- Contracts (`packages/contracts`)
  - Add `.env.example` scoped to the Hardhat setup:
    - `SEPOLIA_RPC_URL`, `ARBITRUM_SEPOLIA_RPC_URL` used by `hardhat.config.ts` networks.
    - `PRIVATE_KEY` used for deployments on Sepolia / Arbitrum Sepolia.
    - `ETHERSCAN_API_KEY`, `ARBISCAN_API_KEY` used for Etherscan/Arbiscan verification.
    - `CHAINLINK_ROUTER`, `SUBSCRIPTION_ID`, `DON_ID` documenting Chainlink Functions configuration.

- Frontend (`apps/frontend`)
  - Add `.env.example` describing app-facing env vars:
    - `NEXT_PUBLIC_BOUNTY_REGISTRY_ADDRESS` for the `BountyRegistry` address used by wagmi.
    - `NEXT_PUBLIC_DATA_REGISTRY_ADDRESS` for the `DataRegistry` address.
    - `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` for the WalletConnect project ID consumed in `WalletProvider`.

- Gitignore
  - Update `apps/frontend/.gitignore` to:
    - Continue ignoring real `.env*` files.
    - Explicitly allow `apps/frontend/.env.example` to be committed.

## Testing

- No runtime changes; only documentation/env-example additions.
- Verified:
  - Existing `hardhat.config.ts` still reads from the root `.env`.
  - Frontend continues to read `NEXT_PUBLIC_*` variables as before; the example files just document and standardize them.

## Notes

- New contributors can now:
  - Copy `.env.example` at the root → `.env` and fill in shared credentials.
  - Copy `apps/frontend/.env.example` → `.env.local` (or `.env`) and provide contract addresses + WalletConnect project ID.
  - Optionally copy `packages/contracts/.env.example` → `.env` when working directly inside the contracts package.
  
  
  Closes #45

## Summary by Sourcery

Add example environment variable templates across the monorepo to document required configuration for contracts and the frontend, and adjust ignore rules to allow committing these example files.

Build:
- Update frontend .gitignore to continue ignoring real env files while allowing the .env.example file to be committed.

Documentation:
- Add root-level .env.example documenting shared RPC, keys, verification, Chainlink, contract address, and WalletConnect variables.
- Add contracts package .env.example describing Hardhat RPC, deployment key, verification, and Chainlink configuration.
- Add frontend app .env.example listing required public contract address and WalletConnect variables for local setup.

Chores:
- Standardize environment configuration documentation to simplify onboarding for new contributors.