### PR TITLE
chore: align README environment setup with .env.example files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ ARBISCAN_API_KEY=your_arbiscan_key
 CHAINLINK_ROUTER=0xb83E47C2bC239B3bf370bc41e1459A34b41238D0
 SUBSCRIPTION_ID=your_subscription_id
 DON_ID=fun-ethereum-sepolia-1
+
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=your_walletconnect_project_id
+NEXT_PUBLIC_BOUNTY_REGISTRY_ADDRESS=0xYourBountyRegistryAddress
+NEXT_PUBLIC_DATA_REGISTRY_ADDRESS=0xYourDataRegistryAddress
+

--- a/README.md
+++ b/README.md
@@ -62,34 +62,73 @@ pnpm install
 
 ### 2. Environment Setup
 
-Create `.env` files in the appropriate packages:
+Use the provided example files as a starting point and copy them to real `.env` files:
 
-**`packages/contracts/.env`:**
+1. **Root env (shared defaults)**
 
-```env
-# Network RPC URLs
-SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
-ARBITRUM_SEPOLIA_RPC_URL=https://arb-sepolia.g.alchemy.com/v2/YOUR_KEY
+   Copy `.env.example` to `.env` at the repository root:
 
-# Deployment
-PRIVATE_KEY=your_private_key_here
+   ```bash
+   cp .env.example .env
+   ```
 
-# Verification
-ETHERSCAN_API_KEY=your_etherscan_key
-ARBISCAN_API_KEY=your_arbiscan_key
+   Example contents:
 
-# Chainlink
-CHAINLINK_ROUTER=0xb83E47C2bC239B3bf370bc41e1459A34b41238D0  # Sepolia
-SUBSCRIPTION_ID=your_subscription_id
-DON_ID=fun-ethereum-sepolia-1
-```
+   ```env
+   SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
+   ARBITRUM_SEPOLIA_RPC_URL=https://arb-sepolia.g.alchemy.com/v2/YOUR_KEY
+   PRIVATE_KEY=your_private_key_here
+   ETHERSCAN_API_KEY=your_etherscan_key
+   ARBISCAN_API_KEY=your_arbiscan_key
 
-**`apps/frontend/.env.local`:**
+   CHAINLINK_ROUTER=0xb83E47C2bC239B3bf370bc41e1459A34b41238D0
+   SUBSCRIPTION_ID=your_subscription_id
+   DON_ID=fun-ethereum-sepolia-1
 
-```env
-NEXT_PUBLIC_BOUNTY_REGISTRY=0x...  # Deployed contract address
-NEXT_PUBLIC_DATA_REGISTRY=0x...
-```
+   NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=your_walletconnect_project_id
+   NEXT_PUBLIC_BOUNTY_REGISTRY_ADDRESS=0xYourBountyRegistryAddress
+   NEXT_PUBLIC_DATA_REGISTRY_ADDRESS=0xYourDataRegistryAddress
+   ```
+
+2. **Contracts env**
+
+   Inside `packages/contracts`, copy `.env.example` to `.env`:
+
+   ```bash
+   cd packages/contracts
+   cp .env.example .env
+   ```
+
+   Example contents (must match the example file):
+
+   ```env
+   SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
+   ARBITRUM_SEPOLIA_RPC_URL=https://arb-sepolia.g.alchemy.com/v2/YOUR_KEY
+   PRIVATE_KEY=your_private_key_here
+   ETHERSCAN_API_KEY=your_etherscan_key
+   ARBISCAN_API_KEY=your_arbiscan_key
+
+   CHAINLINK_ROUTER=0xb83E47C2bC239B3bf370bc41e1459A34b41238D0
+   SUBSCRIPTION_ID=your_subscription_id
+   DON_ID=fun-ethereum-sepolia-1
+   ```
+
+3. **Frontend env**
+
+   Inside `apps/frontend`, copy `.env.example` to `.env.local`:
+
+   ```bash
+   cd apps/frontend
+   cp .env.example .env.local
+   ```
+
+   Example contents:
+
+   ```env
+   NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=your_walletconnect_project_id
+   NEXT_PUBLIC_BOUNTY_REGISTRY_ADDRESS=0xYourBountyRegistryAddress
+   NEXT_PUBLIC_DATA_REGISTRY_ADDRESS=0xYourDataRegistryAddress
+   ```
 
 ### 3. Development
 


### PR DESCRIPTION
This PR aligns the environment setup documentation with the actual `.env.example` files and adds missing examples, so new contributors can configure the repo without guessing variable names or locations.

## Changes

- Root env
  - Add `.env.example` at the repository root with:
    - RPC URLs (`SEPOLIA_RPC_URL`, `ARBITRUM_SEPOLIA_RPC_URL`)
    - Deployment/verification keys (`PRIVATE_KEY`, `ETHERSCAN_API_KEY`, `ARBISCAN_API_KEY`)
    - Chainlink config (`CHAINLINK_ROUTER`, `SUBSCRIPTION_ID`, `DON_ID`)
    - Frontend envs (`NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID`, `NEXT_PUBLIC_BOUNTY_REGISTRY_ADDRESS`, `NEXT_PUBLIC_DATA_REGISTRY_ADDRESS`)

- Contracts env
  - Update `packages/contracts/.env.example` to:
    - Match the root contracts-related variables and placeholders exactly.
    - Include Chainlink-related fields (`CHAINLINK_ROUTER`, `SUBSCRIPTION_ID`, `DON_ID`) used in deployment/config.

- Frontend env
  - Add `apps/frontend/.env.example` with:
    - `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID`
    - `NEXT_PUBLIC_BOUNTY_REGISTRY_ADDRESS`
    - `NEXT_PUBLIC_DATA_REGISTRY_ADDRESS`
  - Variable names now match the actual code usage (`WalletProvider`, `app/constants/contracts.ts`).

- README
  - Rewrite “2. Environment Setup” to use the new `.env.example` files as the single source of truth:
    - Root: `cp .env.example .env`
    - Contracts: `cp packages/contracts/.env.example packages/contracts/.env`
    - Frontend: `cp apps/frontend/.env.example apps/frontend/.env.local`
  - Example blocks in the README now mirror the `.env.example` files exactly (same variable names and placeholders).

## Acceptance Criteria

- A new contributor can:
  - Copy the provided `.env.example` files into `.env` / `.env.local`
  - Fill in secrets and be able to run contracts + frontend without guessing variable names or locations.

- No mismatch between:
  - Variable names shown in README environment snippets, and
  - Variable names in:
    - `.env.example` (root)
    - `packages/contracts/.env.example`
    - `apps/frontend/.env.example`

## Testing

- Documentation / config-only changes:
  - No code behavior changes.
  - Verified that env variable names referenced in:
    - `apps/frontend/app/components/WalletProvider.tsx`
    - `apps/frontend/app/constants/contracts.ts`
  - match those in the updated `.env.example` files and README snippets.

## Summary by Sourcery

Align environment setup documentation with new example env files for root, contracts, and frontend to remove guesswork for contributors.

Documentation:
- Rewrite README environment setup section to reference copying .env.example files for root, contracts, and frontend and to show examples that mirror those files exactly.

Chores:
- Add a root .env.example defining shared RPC, key, Chainlink, and frontend env variables.
- Update contracts .env.example to match root contracts-related variables including Chainlink settings.
- Add apps/frontend .env.example with the public env variables required by the frontend.